### PR TITLE
Defer ensureReproducible evaluation until tasks are configured

### DIFF
--- a/src/main/groovy/com/bsycorp/gradle/jib/JibPlugin.java
+++ b/src/main/groovy/com/bsycorp/gradle/jib/JibPlugin.java
@@ -23,19 +23,20 @@ public class JibPlugin implements Plugin<Project> {
         });
         project.getTasks().register("pushImage", PushImageTask.class);
 
-        if (extension.getEnsureReproducible().get()) {
-            project.getTasks().withType(Zip.class).configureEach(task -> {
-                task.setPreserveFileTimestamps(false);
-                task.setReproducibleFileOrder(true);
-            });
-            project.getTasks().withType(Jar.class).configureEach(task -> {
-                task.setPreserveFileTimestamps(false);
-                task.setReproducibleFileOrder(true);
-            });
-            project.getTasks().withType(Tar.class).configureEach(task -> {
-                task.setPreserveFileTimestamps(false);
-                task.setReproducibleFileOrder(true);
-            });
-        }
+        project.getTasks().withType(Zip.class).configureEach(task -> {
+            var reproducible = extension.getEnsureReproducible().get();
+            task.setPreserveFileTimestamps(!reproducible);
+            task.setReproducibleFileOrder(reproducible);
+        });
+        project.getTasks().withType(Jar.class).configureEach(task -> {
+            var reproducible = extension.getEnsureReproducible().get();
+            task.setPreserveFileTimestamps(!reproducible);
+            task.setReproducibleFileOrder(reproducible);
+        });
+        project.getTasks().withType(Tar.class).configureEach(task -> {
+            var reproducible = extension.getEnsureReproducible().get();
+            task.setPreserveFileTimestamps(!reproducible);
+            task.setReproducibleFileOrder(reproducible);
+        });
     }
 }


### PR DESCRIPTION
Because when the plugin is applied, the property is always the convention.